### PR TITLE
Add getting started tutorial for ChatModule

### DIFF
--- a/tutorial/tutorial_chat_module_getting_started.ipynb
+++ b/tutorial/tutorial_chat_module_getting_started.ipynb
@@ -1,0 +1,249 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Getting Started with MLC-LLM in Python\n",
+    "\n",
+    "Here's a quick overview of how to get started with the MLC-LLM `ChatModule` in Python. In this tutorial, we will chat with the [Vicuna-7B](https://huggingface.co/lmsys/vicuna-7b-delta-v1.1) model, which was trained by fine-tuning LLaMa and developed by LMSYS."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Environment Setup\n",
+    "\n",
+    "Let's set up your environment, so you can successfully run the `ChatModule`. First, lets set up the Conda environment which we'll be running this notebook in.\n",
+    "\n",
+    "```bash\n",
+    "conda create --name mlc-llm python=3.10\n",
+    "conda activate mlc-llm\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, let's download the MLC-AI and MLC-Chat nightly build packages. Go to https://mlc.ai/package/ and replace the command below with the one that is appropriate for your hardware and OS. Let's say we are using CUDA 11.6 on Linux."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install --pre --force-reinstall mlc-ai-nightly-cu116 mlc-chat-nightly-cu116 -f https://mlc.ai/wheels"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, we can clone the [MLC-LLM project](https://github.com/mlc-ai/mlc-llm)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!git clone git@github.com:mlc-ai/mlc-llm.git\n",
+    "!cd mlc-llm\n",
+    "!git submodule update --init --recursive"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, let's download the model weights for the Vicuna-7B model and the prebuilt model libraries from Github. In order to download the large weights, we'll have to use `git lfs`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!conda install git git-lfs\n",
+    "!git lfs install"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!mkdir -p mlc-llm/dist/prebuilt\n",
+    "!git clone https://github.com/mlc-ai/binary-mlc-llm-libs.git mlc-llm/dist/prebuilt/lib"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!git clone https://huggingface.co/mlc-ai/mlc-chat-vicuna-v1-7b-q3f16_0\n",
+    "!mv mlc-chat-vicuna-v1-7b-q3f16_0 mlc-llm/dist/prebuilt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Let's Chat\n",
+    "\n",
+    "Before we can chat with the model, we must first import a few libraries and instantiate a `ChatModule` instance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from mlc_chat import ChatModule\n",
+    "import tvm\n",
+    "\n",
+    "from IPython.display import clear_output"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We must invoke the `ChatModule` with the appropriate device type, such as `vulkan`, `cuda`, etc."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cm = ChatModule(target=\"vulkan\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In order to load the model weights and prebuilt model library into the `ChatModule`, we have to first call the `reload` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lib = tvm.runtime.load_module(\"mlc-llm/dist/prebuilt/lib/vicuna-v1-7b-q3f16_0-vulkan.so\")\n",
+    "cm.reload(lib=lib, model_path=\"mlc-llm/dist/prebuilt/mlc-chat-vicuna-v1-7b-q3f16_0\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "That's all that's needed to set up the `ChatModule`. You can now chat with the model by inputting any prompt you'd like. Try it out below!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Hello! How can I help you today?\n"
+     ]
+    }
+   ],
+   "source": [
+    "prompt = input(\"Prompt: \")\n",
+    "cm.prefill(input=prompt)\n",
+    "\n",
+    "msg = None\n",
+    "while not cm.stopped():\n",
+    "    cm.decode()\n",
+    "    msg = cm.get_message()\n",
+    "    clear_output(wait=True)\n",
+    "    print(msg, flush=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To evaluate the speed of the chat bot, you can print some statistics."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'prefill: 130.9 tok/s, decode: 35.8 tok/s'"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cm.runtime_stats_text()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By default, the `ChatModule` will keep a history of your chat. You can run the chat history by running the following."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cm.reset_chat()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "mlc-llm",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This PR adds a getting started tutorial for the Python `ChatModule`, which allows the user to chat with Vicuna-7B locally using prebuilt libs.

[Preview](https://github.com/sudeepag/notebooks/blob/9a3299896f5a982368d3ae14ff06cbbb824774ea/tutorial/tutorial_chat_module_getting_started.ipynb)