### PR TITLE
Fix Colab link in Getting Started tutorial

### DIFF
--- a/mlc-llm/tutorial_chat_module_getting_started.ipynb
+++ b/mlc-llm/tutorial_chat_module_getting_started.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "Here's a quick overview of how to get started with the MLC-LLM `ChatModule` in Python. In this tutorial, we will chat with the [Llama 2](https://ai.meta.com/llama/) model. For the easiest setup, we recommend trying this out in a Google Colab notebook. Click the button below to get started!\n",
     "\n",
-    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/mlc-ai/notebooks/blob/85064a6b3fbcd30e6dd5be72ef88a90383127f3c/mlc-llm/tutorial_chat_module_getting_started.ipynb\">\n",
+    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/mlc-ai/notebooks/blob/main/mlc-llm/tutorial_chat_module_getting_started.ipynb\">\n",
     "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
     "</a>"
    ]


### PR DESCRIPTION
Fix the Open in Colab link in the getting started tutorial.